### PR TITLE
Support of serialization for subclasses of NewType<NEWTYPE,A,PRED>

### DIFF
--- a/LanguageExt.Bson.Tests/Serialization/NewTypeSerializerTest.cs
+++ b/LanguageExt.Bson.Tests/Serialization/NewTypeSerializerTest.cs
@@ -1,0 +1,78 @@
+using System;
+using FluentAssertions;
+using LanguageExt.ClassInstances;
+using LanguageExt.ClassInstances.Const;
+using LanguageExt.ClassInstances.Pred;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using Xunit;
+
+namespace LanguageExt.Bson.Serialization
+{
+    internal class ConstrainedString : NewType<ConstrainedString, string, StrLen<I4, I6>>
+    {
+        internal ConstrainedString(string value) : base(value) { }
+    }
+
+    internal class ConstrainedInt : NewType<ConstrainedInt, int, Range<TInt, int, I100, I200>>
+    {
+        internal ConstrainedInt(int value) : base(value) { }
+    }
+
+    internal class NewTypeObject
+    {
+        public ConstrainedString ConstrainedString { get; set; }
+        public ConstrainedInt ConstrainedInt { get; set; }
+    }
+    
+    public class NewTypeSerializerTest : WithBsonSerializerSetup
+    {
+        [Fact]
+        public void ConstrainedString_must_be_serialized_to_string()
+        {
+            var bson = new NewTypeObject
+            {
+                ConstrainedString = ConstrainedString.New("1234"),
+                ConstrainedInt = ConstrainedInt.New(150)
+            }.ToBsonDocument();
+
+            bson.Contains("ConstrainedString").Should().BeTrue();
+            bson["ConstrainedString"].AsString.Should().Be("1234");
+            bson.Contains("ConstrainedInt").Should().BeTrue();
+            bson["ConstrainedInt"].AsInt32.Should().Be(150);
+        }
+        
+        [Fact]
+        public void Valid_string_must_be_deserialized_to_ConstrainedString()
+        {
+            var bson = new BsonDocument
+            {
+                ["ConstrainedString"] = new BsonString("1234"),
+                ["ConstrainedInt"] = new BsonInt32(150)
+            };
+
+            var doc = (NewTypeObject) BsonSerializer.Deserialize(bson, typeof(NewTypeObject));
+
+            doc.Should().BeEquivalentTo(new NewTypeObject
+            {
+                ConstrainedString = ConstrainedString.New("1234"),
+                ConstrainedInt = ConstrainedInt.New(150)
+            });
+        }
+        
+        [Fact]
+        public void Invalid_string_must_not_be_deserialized_to_ConstrainedString()
+        {
+            var bson = new BsonDocument
+            {
+                ["ConstrainedString"] = new BsonString("123"),
+                ["ConstrainedInt"] = new BsonInt32(150)
+            };
+
+            FluentActions.Invoking(() => BsonSerializer.Deserialize(bson, typeof(NewTypeObject)))
+                .Should()
+                .Throw<FormatException>("The string is not a valid value for the ConstrainedString type")
+                .WithMessage("*Specified argument was out of the range of valid values. (Parameter 'value')*");
+        }
+    }
+}

--- a/LanguageExt.Bson/Serialization/LanguageExtCollectionSerializationProvider.cs
+++ b/LanguageExt.Bson/Serialization/LanguageExtCollectionSerializationProvider.cs
@@ -43,6 +43,11 @@ namespace LanguageExt.Bson.Serialization
                     return CreateGenericSerializer(typeof(MapSerializer<,>), type.GetGenericArguments(), registry);
                 }
             }
+
+            if (type.IsSubclassOfGeneric(typeof(NewType<,,>), out var newType))
+            {
+                return CreateGenericSerializer(typeof(NewTypeSerializer<,,>), newType.GetGenericArguments(), registry);
+            }
             
             // fall back to default mongo serialization providers
             return null;

--- a/LanguageExt.Bson/Serialization/NewTypeSerializer.cs
+++ b/LanguageExt.Bson/Serialization/NewTypeSerializer.cs
@@ -1,0 +1,31 @@
+using LanguageExt.TypeClasses;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace LanguageExt.Bson.Serialization
+{
+    /// <summary>
+    /// Serializes internal value of the NewType based objects
+    /// </summary>
+    /// <typeparam name="A"></typeparam>
+    public class NewTypeSerializer<NEWTYPE,A,PRED> : SerializerBase<NewType<NEWTYPE,A,PRED>>
+        where NEWTYPE : NewType<NEWTYPE,A,PRED>
+        where PRED : struct, Pred<A>
+    {
+        private readonly IBsonSerializer<A> _itemSerializer;
+
+        public NewTypeSerializer(IBsonSerializerRegistry registry) => _itemSerializer = registry.GetSerializer<A>();
+
+        public override NewType<NEWTYPE,A,PRED> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+            => NewType<NEWTYPE,A,PRED>.New(_itemSerializer.Deserialize(context, GetItemDeserializationArgs(args)));
+
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, NewType<NEWTYPE,A,PRED> value)
+            => value.Iter(a => _itemSerializer.Serialize(context, GetItemSerializationArgs(args), a));
+
+        private static BsonDeserializationArgs GetItemDeserializationArgs(BsonDeserializationArgs args)
+            => ArgumentHelper.GetSpecificDeserializationArgs(args, 1);
+
+        private static BsonSerializationArgs GetItemSerializationArgs(BsonSerializationArgs args)
+            => ArgumentHelper.GetSpecificSerializationArgs(args, 1);
+    }
+}

--- a/LanguageExt.Bson/Serialization/TypeHelper.cs
+++ b/LanguageExt.Bson/Serialization/TypeHelper.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace LanguageExt.Bson.Serialization
+{
+    public static class TypeHelper
+    {
+        public static bool IsSubclassOfGeneric(this Type type, Type generic, out Type found) {
+            while (type != null && type != typeof(object)) {
+                var current = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+                if (generic == current)
+                {
+                    found = type;
+                    return true;
+                }
+                type = type.BaseType;
+            }
+            found = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Hi. I have created the support for the NewTypes subclasses to be unboxed and their Value serialized.

However, I couldn't figure out how to deal with the case when I need to provide an alternative Bson type representation for a string serializer of the internal Value. For example, I have an ImageId class inherited from the NewType<,,> and in my Image record I use the ImageId class as the Id. I would like not only the Value to be extracted from the ImageId type, but also serialized with the ObjectId representation. For the string typed Id I would just specify the string serializer like that:

cm.MapMember(x => x.Id).SetSerializer(new StringSerializer(BsonType.ObjectId));

But with the NewType<,,> serializer I just get the string serializer from the registry and don't really have the details about which particular member map is associated with the currently serialized member. Can you think of any ideas?

Thanks,
Denys